### PR TITLE
Correcting syntax compatible for bash less than 4.0

### DIFF
--- a/PX_Gather_Logs/px_gather_logs.sh
+++ b/PX_Gather_Logs/px_gather_logs.sh
@@ -65,7 +65,8 @@ done
 
 # Prompt for namespace if not provided
 if [[ -z "$namespace" ]]; then
-  read -p "Enter the namespace: " namespace && namespace=${namespace,,}
+  read -p "Enter the namespace: " namespace
+  namespace=$(echo "$namespace" | tr '[:upper:]' '[:lower:]')
   if [[ -z "$namespace" ]]; then
     echo "Error: Namespace cannot be empty."
     exit 1
@@ -102,7 +103,8 @@ fi
 
 # Prompt for option if not provided
 if [[ -z "$option" ]]; then
-  read -p "Choose an option (PX/PXB) (Enter PX for Portworx Enterprise/CSI, Enter PXB for PX Backup): " option && option=${option^^}
+  read -p "Choose an option (PX/PXB) (Enter PX for Portworx Enterprise/CSI, Enter PXB for PX Backup): " option
+  option=$(echo "$option" | tr '[:lower:]' '[:upper:]')
   if [[ "$option" != "PX" && "$option" != "PXB" ]]; then
     echo "Error: Invalid option. Choose either 'PX' or 'PXB'."
     exit 1


### PR DESCRIPTION
Correcting syntax compatible for bash less than 4.0

Update px_gather_logs.sh - Correcting syntax compatible for bash less than 4.0

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

