### PR TITLE
New extract added via PXE 3.6/OP 26.2.X release +PX OP derrivation changes

### DIFF
--- a/px_gather_logs/px_gather_logs.sh
+++ b/px_gather_logs/px_gather_logs.sh
@@ -23,7 +23,7 @@
 #
 # ================================================================
 
-SCRIPT_VERSION="26.6.2"
+SCRIPT_VERSION="26.6.3"
 
 
 # Function to display usage
@@ -645,6 +645,10 @@ if [[ "$option" == "PX" ]]; then
     "get storagenodeinitiators -o yaml"
     "get purestoragecluster -n $namespace"
     "get purestoragecluster -n $namespace -o yaml"
+    "get nodedrain -n $namespace"
+    "get nodedrain -n $namespace -o yaml"
+    "get portworxdiags -n $namespace"
+    "get portworxdiags -n $namespace -o yaml"
     
   )
   output_files=(
@@ -757,6 +761,10 @@ if [[ "$option" == "PX" ]]; then
     "portworx/px_csi/storagenodeinitiators.yaml"
     "portworx/px_csi/purestoragecluster.txt"
     "portworx/px_csi/purestoragecluster.yaml"
+    "portworx/nodedrain.txt"
+    "portworx/nodedrain.yaml"
+    "portworx/portworxdiags.txt"
+    "portworx/portworxdiags.yaml"
 
 
   )
@@ -789,6 +797,10 @@ if [[ "$option" == "PX" ]]; then
     "cluster defrag schedule show -j"
     "cluster defrag status"
     "cluster defrag status -j"
+    "kds list"
+    "kds list -j"
+    "sv pool migrate list"
+    "sv pool migrate list -j"
 
   )
   pxctl_output_files=(
@@ -820,6 +832,10 @@ if [[ "$option" == "PX" ]]; then
     "portworx/pxctl_out/pxctl_defrag_schedules.json"
     "portworx/pxctl_out/pxctl_defrag_status.txt"
     "portworx/pxctl_out/pxctl_defrag_status.json"
+    "portworx/pxctl_out/pxctl_kds_list.txt"
+    "portworx/pxctl_out/pxctl_kds_list.json"
+    "portworx/pxctl_out/pxctl_pool_migrate_list.txt"
+    "portworx/pxctl_out/pxctl_pool_migrate_list.json"
     
   )
 

--- a/px_gather_logs/px_gather_logs.sh
+++ b/px_gather_logs/px_gather_logs.sh
@@ -1928,6 +1928,16 @@ generate_cluster_overview() {
     for f in "$output_dir"/portworx/workloads/portworx-operator-*.yaml; do
       [[ -f "$f" ]] || continue
       operator_version=$(awk '/image: .*px-operator:/ {sub(/.*px-operator:/,""); print; exit}' "$f")
+      # Fallback for older PX Operator in OCP where image is pinned by
+      # digest: derive version from OPERATOR_CONDITION_NAME env var
+      if [[ -z "$operator_version" ]]; then
+        operator_version=$(awk '
+          /name:[[:space:]]*OPERATOR_CONDITION_NAME/ {found=1; next}
+          found && /value:[[:space:]]*portworx-operator\.v/ {
+            sub(/.*portworx-operator\.v/,""); gsub(/["'"'"']/,"")
+            sub(/[[:space:]]+$/,""); print; exit
+          }' "$f")
+      fi
       [[ -n "$operator_version" ]] && break
     done
   fi


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

- New extract added via PXE 3.6/OP 26.2.X release
- Add fallback to derive PX Operator version from OPERATOR_CONDITION_NAME for OCP

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

